### PR TITLE
[DB] Allow `DB::raw` expressions as a value for mass update

### DIFF
--- a/src/MassUpdatable.php
+++ b/src/MassUpdatable.php
@@ -12,6 +12,7 @@ use Iksaku\Laravel\MassUpdate\Exceptions\UnexpectedModelClassException;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Contracts\Support\Jsonable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
@@ -59,6 +60,10 @@ trait MassUpdatable
 
             if ($value instanceof Jsonable) {
                 $value = $value->toJson();
+            }
+
+            if ($value instanceof Expression) {
+                $value = $value->getValue($query->getGrammar());
             }
 
             return $query->getConnection()->getPdo()->quote($value);

--- a/src/MassUpdatable.php
+++ b/src/MassUpdatable.php
@@ -50,6 +50,10 @@ trait MassUpdatable
                 return $value;
             }
 
+            if ($value instanceof Expression) {
+                return $value->getValue($query->getGrammar());
+            }
+
             if ($value instanceof Arrayable) {
                 $value = $value->toArray();
             }
@@ -60,10 +64,6 @@ trait MassUpdatable
 
             if ($value instanceof Jsonable) {
                 $value = $value->toJson();
-            }
-
-            if ($value instanceof Expression) {
-                $value = $value->getValue($query->getGrammar());
             }
 
             return $query->getConnection()->getPdo()->quote($value);


### PR DESCRIPTION
# Why
Allow passing in `DB::raw` `Expressions` so that the compiled CASE WHEN can use the current column values. 

# How
Hook into `$value` inspection code and add a case for `Illuminate\Contracts\Database\Query\Expression` type. Pull out the raw string value by passing along the query's current grammar (`Illuminate/Database/Query/Grammars/Grammar`).

# Ex
```php
User::massUpdate([
   [ 'id' => 1, 'receipt_limit' => DB::raw('receipt_limit - 1']
]);
```

Before this change, it would quote this value: `receipt_limit = 'receipt_limit - 1'` which wasn't valid SQL syntax. With the change, it behaves as expected.