### PR TITLE
feat: backport fix for escaping PostgreSQL boolean values from 2.x

### DIFF
--- a/src/MassUpdatable.php
+++ b/src/MassUpdatable.php
@@ -37,18 +37,6 @@ trait MassUpdatable
         }
 
         $quoteValue = function (mixed $value) use ($query) {
-            if (is_null($value)) {
-                return 'NULL';
-            }
-
-            if (is_bool($value)) {
-                return (int) $value;
-            }
-
-            if (is_int($value)) {
-                return $value;
-            }
-
             if ($value instanceof Arrayable) {
                 $value = $value->toArray();
             }
@@ -61,7 +49,7 @@ trait MassUpdatable
                 $value = $value->toJson();
             }
 
-            return $query->getConnection()->getPdo()->quote($value);
+            return $query->getGrammar()->escape($value);
         };
 
         $uniqueBy = Arr::wrap($uniqueBy ?? $this->getMassUpdateKeyName());

--- a/tests/Feature/CompileMultipleTypesTest.php
+++ b/tests/Feature/CompileMultipleTypesTest.php
@@ -12,7 +12,7 @@ it('can compile NULL values', function () {
         $user->fill(['name' => null]),
     ]);
 
-    expect(DB::getQueryLog()[0]['query'])->toContain('THEN NULL');
+    expect(DB::getQueryLog()[0]['query'])->toContain('THEN null');
 
     expect($user->refresh()->name)->toBeNull();
 });
@@ -51,7 +51,7 @@ it('can compile numeric values', function (int $rank, float $height) {
         $user->fill(compact('rank', 'height')),
     ]);
 
-    expect(DB::getQueryLog()[0]['query'])->toContain('THEN 10', "THEN '1.7'");
+    expect(DB::getQueryLog()[0]['query'])->toContain('THEN 10', 'THEN 1.7');
 
     expect($user->refresh())
         ->rank->toBe($rank)


### PR DESCRIPTION
Hello!

Since this package dropped support for Laravel <10.x, we can safely backport fix from `2.x` branch to main right away.
This change has been tested with PostgreSQL 16.11 & Laravel 12.52 & PHP8.3 with no errors and code working as expected.

Fixes https://github.com/iksaku/laravel-mass-update/issues/15